### PR TITLE
Take `VmiCore` and `Os` by reference in `VmiSession`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
         with:
           components: clippy
 
+      - name: Set up cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Run clippy
         run: cargo +nightly clippy
 
@@ -104,6 +107,9 @@ jobs:
         with:
           components: rustfmt
 
+      - name: Set up cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Run rustfmt
         run: cargo +nightly fmt --all -- --check
 
@@ -117,6 +123,9 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Run build
         run: cargo build
@@ -135,6 +144,9 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Run check
         run: cargo check --examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,3 +120,21 @@ jobs:
 
       - name: Run build
         run: cargo build
+
+  #
+  # It would be better to run `cargo build --examples` but since the Xen
+  # is not installed in the CI environment, the examples will not compile.
+  #
+  examples:
+    name: cargo check --examples
+    runs-on: ubuntu-latest
+    # needs: xen-install
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run check
+        run: cargo check --examples

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create the VMI session.
     let os = WindowsOs::<VmiXenDriver<Amd64>>::new(&profile)?;
-    let session = VmiSession::new(core, os);
+    let session = VmiSession::new(&core, &os);
 
     // Get the list of processes and print them.
     let _pause_guard = session.pause_guard()?;

--- a/crates/vmi-macros/src/derive_os_trait.rs
+++ b/crates/vmi-macros/src/derive_os_trait.rs
@@ -137,6 +137,7 @@ fn transform_return_type(return_type: &ReturnType) -> TokenStream {
 fn generate_impl_fns(item_fn: impl ItemFnExt) -> Option<TraitFn> {
     let sig = item_fn.sig();
     let ident = &sig.ident;
+    let generics = &sig.generics;
 
     let mut session_args = Vec::new();
     let mut session_arg_names = Vec::new();
@@ -178,8 +179,8 @@ fn generate_impl_fns(item_fn: impl ItemFnExt) -> Option<TraitFn> {
     let doc = item_fn.doc();
     let os_session_fn = quote! {
         #(#doc)*
-        pub fn #ident(&self, #(#session_args),*) #return_type {
-            self.0.os.#ident(&self.0.core, #(#session_arg_names),*)
+        pub fn #ident #generics(&self, #(#session_args),*) #return_type {
+            self.os.#ident(self.core, #(#session_arg_names),*)
         }
     };
 
@@ -187,10 +188,10 @@ fn generate_impl_fns(item_fn: impl ItemFnExt) -> Option<TraitFn> {
     let doc = item_fn.doc();
     let os_context_fn = quote! {
         #(#doc)*
-        pub fn #ident(&self, #(#context_args),*) #return_type {
-            self.0.session.os.#ident(
-                &self.0.session,
-                self.0.event.registers(),
+        pub fn #ident #generics(&self, #(#context_args),*) #return_type {
+            self.session.os.#ident(
+                &self.session,
+                self.event.registers(),
                 #(#context_arg_names),*
             )
         }
@@ -200,7 +201,7 @@ fn generate_impl_fns(item_fn: impl ItemFnExt) -> Option<TraitFn> {
     let doc = item_fn.doc();
     let os_session_prober_fn = quote! {
         #(#doc)*
-        pub fn #ident(&self, #(#session_args),*) #prober_return_type {
+        pub fn #ident #generics(&self, #(#session_args),*) #prober_return_type {
             self.0.check_result(
                 self.0
                     .session
@@ -214,7 +215,7 @@ fn generate_impl_fns(item_fn: impl ItemFnExt) -> Option<TraitFn> {
     let doc = item_fn.doc();
     let os_context_prober_fn = quote! {
         #(#doc)*
-        pub fn #ident(&self, #(#context_args),*) #prober_return_type {
+        pub fn #ident #generics(&self, #(#context_args),*) #prober_return_type {
             self.0.check_result(
                 self.0
                     .context

--- a/crates/vmi-macros/src/lib.rs
+++ b/crates/vmi-macros/src/lib.rs
@@ -2,7 +2,9 @@
 
 mod derive_os_impl;
 mod derive_os_trait;
+mod lifetime;
 mod method;
+mod transform;
 
 use proc_macro::TokenStream;
 

--- a/crates/vmi-macros/src/lifetime.rs
+++ b/crates/vmi-macros/src/lifetime.rs
@@ -1,0 +1,316 @@
+use syn::{
+    AngleBracketedGenericArguments, FnArg, GenericArgument, GenericParam, Generics, Ident,
+    Lifetime, PathArguments, ReturnType, Type, TypeImplTrait, TypeParamBound, TypePath,
+    TypeReference,
+};
+
+pub fn remove_in_generics(generics: &mut Generics, lifetime: &str) {
+    generics.params = generics
+        .params
+        .iter()
+        .filter(|&param| match param {
+            GenericParam::Lifetime(lt) => lt.lifetime.ident != lifetime,
+            _ => true,
+        })
+        .cloned()
+        .collect();
+}
+
+/// Replace the lifetime `'from` with `'to` in the given lifetime.
+///
+/// # Example
+///
+/// Before:
+///
+/// ```rust,ignore
+/// 'from
+/// ```
+///
+/// After:
+///
+/// ```rust,ignore
+/// 'to
+/// ```
+pub fn replace_in_lifetime(lifetime: &mut Lifetime, from: &str, to: &str) {
+    if lifetime.ident != from {
+        return;
+    }
+
+    lifetime.ident = Ident::new(to, lifetime.ident.span());
+}
+
+/// Replace the lifetime `'from` with `'to` in the given angle-bracketed generic arguments.
+///
+/// # Example
+///
+/// Before:
+///
+/// ```rust,ignore
+/// <'from, T>
+/// <Output = &'from T>
+/// ```
+///
+/// After:
+///
+/// ```rust,ignore
+/// <'to, T>
+/// <Output = &'to T>
+/// ```
+pub fn replace_in_angle_bracketed_generic_arguments(
+    args: &mut AngleBracketedGenericArguments,
+    from: &str,
+    to: &str,
+) {
+    for arg in &mut args.args {
+        match arg {
+            GenericArgument::Lifetime(lifetime) => {
+                replace_in_lifetime(lifetime, from, to);
+            }
+            GenericArgument::Type(ty) => replace_in_type(ty, from, to),
+            GenericArgument::Const(_) => {}
+            GenericArgument::AssocType(assoc_type) => {
+                if let Some(generics) = &mut assoc_type.generics {
+                    replace_in_angle_bracketed_generic_arguments(generics, from, to);
+                }
+                replace_in_type(&mut assoc_type.ty, from, to);
+            }
+            GenericArgument::AssocConst(_) => {}
+            GenericArgument::Constraint(constraint) => {
+                if let Some(generics) = &mut constraint.generics {
+                    replace_in_angle_bracketed_generic_arguments(generics, from, to);
+                }
+
+                for bound in &mut constraint.bounds {
+                    replace_in_type_param_bound(bound, from, to);
+                }
+            }
+            _ => panic!("unexpected generic argument"),
+        }
+    }
+}
+
+/// Replace the lifetime `'from` with `'to` in the given generic parameter.
+///
+/// # Example
+///
+/// Before:
+///
+/// ```rust,ignore
+/// 'a: 'from
+/// 'from: 'b
+/// T: 'from
+/// ```
+///
+/// After:
+///
+/// ```rust,ignore
+/// 'a: 'to
+/// 'to: 'b
+/// T: 'to
+/// ```
+pub fn replace_in_generic_param(param: &mut GenericParam, from: &str, to: &str) {
+    match param {
+        GenericParam::Lifetime(lifetime) => {
+            replace_in_lifetime(&mut lifetime.lifetime, from, to);
+
+            for bound in &mut lifetime.bounds {
+                replace_in_lifetime(bound, from, to);
+            }
+        }
+        GenericParam::Type(ty) => {
+            for bound in &mut ty.bounds {
+                replace_in_type_param_bound(bound, from, to);
+            }
+
+            if let Some(default) = &mut ty.default {
+                replace_in_type(default, from, to);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Replace the lifetime `'from` with `'to` in the given type parameter bound.
+///
+/// # Example
+///
+/// Before:
+///
+/// ```rust,ignore
+///
+pub fn replace_in_type_param_bound(bound: &mut TypeParamBound, from: &str, to: &str) {
+    match bound {
+        TypeParamBound::Trait(trait_bound) => {
+            if let Some(lifetimes) = &mut trait_bound.lifetimes {
+                for param in lifetimes.lifetimes.iter_mut() {
+                    replace_in_generic_param(param, from, to);
+                }
+            }
+        }
+        TypeParamBound::Lifetime(lifetime) => replace_in_lifetime(lifetime, from, to),
+        _ => panic!("unexpected type parameter bound"),
+    }
+}
+
+/// Replace the lifetime `'from` with `'to` in the given type path.
+///
+/// # Example
+///
+/// Before:
+///
+/// ```rust,ignore
+/// Foo<'from, T>
+/// ```
+///
+/// After:
+///
+/// ```rust,ignore
+/// Foo<'to, T>
+/// ```
+pub fn replace_in_type_path(type_path: &mut TypePath, from: &str, to: &str) {
+    let segment = match type_path.path.segments.last_mut() {
+        Some(segment) => segment,
+        None => return,
+    };
+
+    let args = match &mut segment.arguments {
+        PathArguments::AngleBracketed(args) => args,
+        _ => return,
+    };
+
+    replace_in_angle_bracketed_generic_arguments(args, from, to);
+}
+
+/// Replace the lifetime `'from` with `'to` in the given type reference.
+///
+/// # Example
+///
+/// Before:
+///
+/// ```rust,ignore
+/// &'from T<'from>
+/// ```
+///
+/// After:
+///
+/// ```rust,ignore
+/// &'to T<'to>
+/// ```
+pub fn replace_in_type_reference(ty_ref: &mut TypeReference, from: &str, to: &str) {
+    replace_in_type(&mut ty_ref.elem, from, to);
+
+    if let Some(lifetime) = &mut ty_ref.lifetime {
+        replace_in_lifetime(lifetime, from, to);
+    }
+}
+
+/// Replace the lifetime `'from` with `'to` in the given function argument.
+///
+/// # Example
+///
+/// Before:
+///
+/// ```rust,ignore
+/// arg: &'from T
+/// ```
+///
+/// After:
+///
+/// ```rust,ignore
+/// arg: &'to T
+/// ```
+pub fn replace_in_fn_arg(arg: &mut FnArg, from: &str, to: &str) {
+    let pat_type = match arg {
+        FnArg::Typed(pat_type) => pat_type,
+        _ => return,
+    };
+
+    #[allow(clippy::single_match, clippy::needless_return)]
+    match pat_type.ty.as_mut() {
+        Type::Reference(ty_ref) => replace_in_type_reference(ty_ref, from, to),
+        _ => return,
+    }
+}
+
+/// Replace the lifetime `'from` with `'to` in the given type impl trait.
+///
+/// # Example
+///
+/// Before:
+///
+/// ```rust,ignore
+/// impl Trait + 'from
+/// impl Trait<Output = &'from T>
+/// ```
+///
+/// After:
+///
+/// ```rust,ignore
+/// impl Trait + 'to
+/// impl Trait<Output = &'to T>
+/// ```
+pub fn replace_in_type_impl_trait(impl_trait: &mut TypeImplTrait, from: &str, to: &str) {
+    for bound in &mut impl_trait.bounds {
+        // TODO: Handle `TypeParamBound::TraitBound`
+        if let TypeParamBound::Lifetime(lifetime) = bound {
+            replace_in_lifetime(lifetime, from, to);
+        }
+    }
+}
+
+/// Replace the lifetime `'from` with `'to` in the given type.
+///
+/// # Example
+///
+/// Before:
+///
+/// ```rust,ignore
+/// Foo<'from, T>
+/// impl Trait + 'from
+/// // impl Trait<Output = &'from T> // TODO: Handle this case
+/// ```
+///
+/// After:
+///
+/// ```rust,ignore
+/// Foo<'to, T>
+/// impl Trait + 'to
+/// // impl Trait<Output = &'to T> // TODO: Handle this case
+/// ```
+pub fn replace_in_type(ty: &mut Type, from: &str, to: &str) {
+    match ty {
+        Type::ImplTrait(impl_trait) => replace_in_type_impl_trait(impl_trait, from, to),
+        Type::Path(type_path) => replace_in_type_path(type_path, from, to),
+        _ => {}
+    };
+}
+
+/// Replace the lifetime `'from` with `'to` in the given return type.
+///
+/// # Example
+///
+/// Before:
+///
+/// ```rust,ignore
+/// -> &'from T
+/// -> Result<&'from T, VmiError>
+/// -> Result<T<'from>, VmiError>
+/// -> impl Trait + 'from
+/// -> Result<impl Trait + 'from, VmiError>
+/// ```
+///
+/// After:
+///
+/// ```rust,ignore
+/// -> &'to T
+/// -> Result<&'to T, VmiError>
+/// -> Result<T<'to>, VmiError>
+/// -> impl Trait + 'to
+/// -> Result<impl Trait + 'to, VmiError>
+/// ```
+pub fn replace_in_return_type(return_type: &mut ReturnType, from: &str, to: &str) {
+    match return_type {
+        ReturnType::Type(_, ty) => replace_in_type(ty, from, to),
+        ReturnType::Default => {}
+    }
+}

--- a/crates/vmi-macros/src/transform.rs
+++ b/crates/vmi-macros/src/transform.rs
@@ -1,0 +1,58 @@
+use syn::{GenericArgument, PathArguments, ReturnType, Type};
+
+/// Transform the return type from `Result<T, VmiError>` to
+/// `Result<Option<T>, VmiError>`.
+///
+/// # Example
+///
+/// Before:
+///
+/// ```rust,ignore
+/// -> Result<T, VmiError>
+/// -> Result<impl Trait, VmiError>
+/// -> Result<impl Trait<T> + 'a, VmiError>
+/// ```
+///
+/// After:
+///
+/// ```rust,ignore
+/// -> Result<Option<T>, VmiError>
+/// -> Result<Option<impl Trait>, VmiError>
+/// -> Result<Option<impl Trait<T> + 'a>, VmiError>
+/// ```
+pub fn result_to_result_option(return_type: &ReturnType) -> Option<ReturnType> {
+    let ty = match &return_type {
+        ReturnType::Type(_, ty) => ty,
+        ReturnType::Default => return None,
+    };
+
+    let type_path = match &**ty {
+        Type::Path(type_path) => type_path,
+        _ => return None,
+    };
+
+    let segment = match type_path.path.segments.last() {
+        Some(segment) => segment,
+        None => return None,
+    };
+
+    if segment.ident != "Result" {
+        return None;
+    }
+
+    let args = match &segment.arguments {
+        PathArguments::AngleBracketed(args) => args,
+        _ => return None,
+    };
+
+    if args.args.len() != 2 {
+        return None;
+    }
+
+    let arg_type = match &args.args[0] {
+        GenericArgument::Type(arg_type) => arg_type,
+        _ => return None,
+    };
+
+    Some(syn::parse_quote! { -> Result<Option<#arg_type>, VmiError> })
+}

--- a/crates/vmi-os-windows/src/iterators.rs
+++ b/crates/vmi-os-windows/src/iterators.rs
@@ -1,0 +1,125 @@
+use vmi_core::{os::OsProcess, Architecture, Registers as _, Va, VmiDriver, VmiError, VmiSession};
+
+use crate::{arch::ArchAdapter, WindowsOs, WindowsOsSessionExt as _};
+
+pub struct LinkedListIterator<'a, Driver>
+where
+    Driver: VmiDriver,
+    Driver::Architecture: Architecture + ArchAdapter<Driver>,
+{
+    vmi: VmiSession<'a, Driver, WindowsOs<Driver>>,
+    registers: &'a <Driver::Architecture as Architecture>::Registers,
+    list_head: Va,
+    offset: u64,
+    entry: Option<Va>,
+}
+
+impl<'a, Driver> LinkedListIterator<'a, Driver>
+where
+    Driver: VmiDriver,
+    Driver::Architecture: Architecture + ArchAdapter<Driver>,
+{
+    /// Create a new process iterator.
+    pub fn new(
+        vmi: VmiSession<'a, Driver, WindowsOs<Driver>>,
+        registers: &'a <Driver::Architecture as Architecture>::Registers,
+        list_head: Va,
+        offset: u64,
+    ) -> Self {
+        Self {
+            vmi,
+            registers,
+            list_head,
+            offset,
+            entry: None,
+        }
+    }
+
+    fn __first(&mut self) -> Result<Va, VmiError> {
+        self.vmi.read_va(
+            self.registers.address_context(self.list_head),
+            self.registers.address_width(),
+        )
+    }
+
+    fn __next(&mut self) -> Result<Option<Va>, VmiError> {
+        let entry = match self.entry {
+            Some(entry) => entry,
+            None => {
+                let flink = self.__first()?;
+                self.entry = Some(flink);
+                flink
+            }
+        };
+
+        if entry == self.list_head {
+            return Ok(None);
+        }
+
+        self.entry = Some(self.vmi.read_va(
+            self.registers.address_context(entry),
+            self.registers.address_width(),
+        )?);
+
+        Ok(Some(entry - self.offset))
+    }
+}
+
+impl<Driver> Iterator for LinkedListIterator<'_, Driver>
+where
+    Driver: VmiDriver,
+    Driver::Architecture: Architecture + ArchAdapter<Driver>,
+{
+    type Item = Result<Va, VmiError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.__next().transpose()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+pub struct ProcessIterator<'a, Driver>
+where
+    Driver: VmiDriver,
+    Driver::Architecture: Architecture + ArchAdapter<Driver>,
+{
+    inner: LinkedListIterator<'a, Driver>,
+}
+
+impl<'a, Driver> ProcessIterator<'a, Driver>
+where
+    Driver: VmiDriver,
+    Driver::Architecture: Architecture + ArchAdapter<Driver>,
+{
+    /// Create a new process iterator.
+    pub fn new(
+        session: VmiSession<'a, Driver, WindowsOs<Driver>>,
+        registers: &'a <Driver::Architecture as Architecture>::Registers,
+        list_head: Va,
+        offset: u64,
+    ) -> Self {
+        Self {
+            inner: LinkedListIterator::new(session, registers, list_head, offset),
+        }
+    }
+}
+
+impl<Driver> Iterator for ProcessIterator<'_, Driver>
+where
+    Driver: VmiDriver,
+    Driver::Architecture: Architecture + ArchAdapter<Driver>,
+{
+    type Item = Result<OsProcess, VmiError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|result| {
+            result.and_then(|entry| {
+                self.inner
+                    .vmi
+                    .os()
+                    .process_object_to_process(self.inner.registers, entry.into())
+            })
+        })
+    }
+}

--- a/examples/basic-process-list.rs
+++ b/examples/basic-process-list.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create the VMI session.
     tracing::info!("Creating VMI session");
     let os = WindowsOs::<VmiXenDriver<Amd64>>::new(&profile)?;
-    let session = VmiSession::new(core, os);
+    let session = VmiSession::new(&core, &os);
 
     // Get the list of processes and print them.
     let _pause_guard = session.pause_guard()?;

--- a/examples/windows-breakpoint-manager.rs
+++ b/examples/windows-breakpoint-manager.rs
@@ -591,7 +591,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     signal_hook::flag::register(signal_hook::consts::SIGTERM, terminate_flag.clone())?;
 
     let os = WindowsOs::<VmiXenDriver<Amd64>>::new(&profile)?;
-    let session = VmiSession::new(core, os);
+    let session = VmiSession::new(&core, &os);
 
     session.handle(|session| Monitor::new(session, &profile, terminate_flag))?;
 

--- a/examples/windows-recipe-messagebox.rs
+++ b/examples/windows-recipe-messagebox.rs
@@ -18,7 +18,7 @@
 //! DEBUG injector{vcpu=1 rip=0x0000000077c618ca}:memory_access: recipe finished result=0x0000000000000001
 //! ```
 
-mod _common;
+mod common;
 
 use vmi::{
     arch::amd64::Amd64,
@@ -62,7 +62,7 @@ where
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (vmi, profile) = _common::create_vmi_session()?;
+    let (vmi, profile) = common::create_vmi_session()?;
 
     let processes = {
         let _pause_guard = vmi.pause_guard()?;

--- a/examples/windows-recipe-writefile-advanced.rs
+++ b/examples/windows-recipe-writefile-advanced.rs
@@ -48,7 +48,7 @@
 //! DEBUG injector{vcpu=2 rip=0x0000000077c618ca}:memory_access: recipe finished result=0x0000000000000001
 //! ```
 
-mod _common;
+mod common;
 
 use vmi::{
     arch::amd64::Amd64,
@@ -295,7 +295,7 @@ where
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (vmi, profile) = _common::create_vmi_session()?;
+    let (vmi, profile) = common::create_vmi_session()?;
 
     let processes = {
         let _pause_guard = vmi.pause_guard()?;

--- a/examples/windows-recipe-writefile.rs
+++ b/examples/windows-recipe-writefile.rs
@@ -23,7 +23,7 @@
 //! DEBUG injector{vcpu=0 rip=0x0000000077c62c1a}:memory_access: recipe finished result=0x0000000000000001
 //! ```
 
-mod _common;
+mod common;
 
 use vmi::{
     arch::amd64::Amd64,
@@ -200,7 +200,7 @@ where
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (vmi, profile) = _common::create_vmi_session()?;
+    let (vmi, profile) = common::create_vmi_session()?;
 
     let processes = {
         let _pause_guard = vmi.pause_guard()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@
 //!
 //!     // Create the VMI session.
 //!     let os = WindowsOs::<VmiXenDriver<Amd64>>::new(&profile)?;
-//!     let session = VmiSession::new(core, os);
+//!     let session = VmiSession::new(&core, &os);
 //!
 //!     // Get the list of processes and print them.
 //!     let _pause_guard = session.pause_guard()?;


### PR DESCRIPTION
After this change, `VmiSession` doesn't own the `VmiCore` with the `Os` and instead takes reference to them. This is needed in order to allow future implementation of iterators on the VmiOs trait.

CI is updated to include `cargo check --examples`. It would be better to run `cargo build --examples` instead, however, the CI environment doesn't have Xen installed and the build would fail on linking errors.

Also, CI is updated to use rust cache to speed-up the process.